### PR TITLE
Add `socket report view` command + `--view` flag on `socket report create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,21 @@ npm install -g @socketsecurity/cli
 ```bash
 socket --help
 socket info webtorrent@1.9.1
-socket report create package.json
+socket report create package.json --view
+socket report view QXU8PmK7LfH608RAwfIKdbcHgwEd_ZeWJ9QEGv05FJUQ
 ```
 
 ## Commands
 
 * `socket info <package@version>` - looks up issues for a package
-* `socket report create` - uploads the specified `package.json` and/or `package-lock.json` to create a report on [socket.dev](https://socket.dev/). If only one of a `package.json`/`package-lock.json` has been specified, the other will be automatically found and uploaded if it exists
+* `socket report create <path(s)-to-folder-or-file>` - uploads the specified `package.json` and/or `package-lock.json` to create a report on [socket.dev](https://socket.dev/). If only one of a `package.json`/`package-lock.json` has been specified, the other will be automatically found and uploaded if it exists
+* `socket report view <report-id>` - looks up issues and scores from a report
 
 ## Flags
 
-### Action flags
+### Command specific flags
 
-* `--dry-run` - the `socket report create` supports running the command without actually uploading anything. All CLI tools that perform an action should have a dry run flag
+* `--view` - when set on `socket report create` the command will immediately do a `socket report view` style view of the created report, waiting for the server to complete it
 
 ### Output flags
 
@@ -36,6 +38,7 @@ socket report create package.json
 
 ### Other flags
 
+* `--dry-run` - like all CLI tools that perform an action should have, we have a dry run flag. Eg. `socket report create` supports running the command without actually uploading anything
 * `--debug` - outputs additional debug output. Great for debugging, geeks and us who develop. Hopefully you will never _need_ it, but it can still be fun, right?
 * `--help` - prints the help for the current command. All CLI tools should have this flag
 * `--version` - prints the version of the tool. All CLI tools should have this flag
@@ -45,6 +48,7 @@ socket report create package.json
 * `SOCKET_SECURITY_API_KEY` - if set, this will be used as the API-key
 
 ## Contributing
+
 ### Environment variables for development
 
 * `SOCKET_SECURITY_API_BASE_URL` - if set, this will be the base for all API-calls. Defaults to `https://api.socket.dev/v0/`

--- a/lib/commands/info/index.js
+++ b/lib/commands/info/index.js
@@ -3,27 +3,45 @@
 import chalk from 'chalk'
 import meow from 'meow'
 import ora from 'ora'
-import { ErrorWithCause } from 'pony-cause'
 
+import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api-helpers.js'
 import { ChalkOrMarkdown } from '../../utils/chalk-markdown.js'
-import { AuthError, InputError } from '../../utils/errors.js'
+import { InputError } from '../../utils/errors.js'
 import { getSeveritySummary } from '../../utils/format-issues.js'
 import { printFlagList } from '../../utils/formatting.js'
 import { setupSdk } from '../../utils/sdk.js'
 
-const description = 'Look up info regarding a package'
+/** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
+export const info = {
+  description: 'Look up info regarding a package',
+  async run (argv, importMeta, { parentName }) {
+    const name = parentName + ' info'
 
-/** @type {import('../../utils/meow-with-subcommands').CliSubcommandRun} */
-const run = async (argv, importMeta, { parentName }) => {
-  const name = parentName + ' info'
+    const input = setupCommand(name, info.description, argv, importMeta)
+    const result = input && await fetchPackageData(input.pkgName, input.pkgVersion)
 
+    if (result) {
+      formatPackageDataOutput(result.data, { name, ...input })
+    }
+  }
+}
+
+// Internal functions
+
+/**
+ * @param {string} name
+ * @param {string} description
+ * @param {readonly string[]} argv
+ * @param {ImportMeta} importMeta
+ * @returns {void|{ outputJson: boolean, outputMarkdown: boolean, pkgName: string, pkgVersion: string }}
+ */
+ function setupCommand (name, description, argv, importMeta) {
   const cli = meow(`
     Usage
       $ ${name} <name>
 
     Options
       ${printFlagList({
-        '--debug': 'Output debug information',
         '--json': 'Output result as json',
         '--markdown': 'Output result as markdown',
       }, 6)}
@@ -36,11 +54,6 @@ const run = async (argv, importMeta, { parentName }) => {
     description,
     importMeta,
     flags: {
-      debug: {
-        type: 'boolean',
-        alias: 'd',
-        default: false,
-      },
       json: {
         type: 'boolean',
         alias: 'j',
@@ -83,47 +96,56 @@ const run = async (argv, importMeta, { parentName }) => {
     throw new InputError('Need to specify a version, like eg: webtorrent@1.0.0')
   }
 
-  const socketSdk = await setupSdk()
-
-  const spinner = ora(`Looking up data for version ${pkgVersion} of ${pkgName}`).start()
-
-  /** @type {Awaited<ReturnType<typeof socketSdk.getIssuesByNPMPackage>>} */
-  let result
-
-  try {
-    result = await socketSdk.getIssuesByNPMPackage(pkgName, pkgVersion)
-  } catch (cause) {
-    spinner.fail()
-    throw new ErrorWithCause('Failed to look up package', { cause })
+  return {
+    outputJson,
+    outputMarkdown,
+    pkgName,
+    pkgVersion
   }
+}
+
+/**
+ * @param {string} pkgName
+ * @param {string} pkgVersion
+ * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>>}
+ */
+async function fetchPackageData (pkgName, pkgVersion) {
+  const socketSdk = await setupSdk()
+  const spinner = ora(`Looking up data for version ${pkgVersion} of ${pkgName}`).start()
+  const result = await handleApiCall(socketSdk.getIssuesByNPMPackage(pkgName, pkgVersion), spinner, 'looking up package')
 
   if (result.success === false) {
-    if (result.status === 401 || result.status === 403) {
-      spinner.stop()
-      throw new AuthError(result.error.message)
-    }
-    spinner.fail(chalk.white.bgRed('API returned an error:') + ' ' + result.error.message)
-    process.exit(1)
+    return handleUnsuccessfulApiResponse(result, spinner)
   }
+
+  // Conclude the status of the API call
 
   const issueSummary = getSeveritySummary(result.data)
-
   spinner.succeed(`Found ${issueSummary || 'no'} issues for version ${pkgVersion} of ${pkgName}`)
 
+  return result
+}
+
+/**
+ * @param {import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>["data"]} data
+ * @param {{ name: string, outputJson: boolean, outputMarkdown: boolean, pkgName: string, pkgVersion: string }} context
+ * @returns {void}
+ */
+ function formatPackageDataOutput (data, { name, outputJson, outputMarkdown, pkgName, pkgVersion }) {
+  // If JSON, output and return...
+
   if (outputJson) {
-    console.log(JSON.stringify(result.data, undefined, 2))
+    console.log(JSON.stringify(data, undefined, 2))
     return
   }
+
+  // ...else do the CLI / Markdown output dance
 
   const format = new ChalkOrMarkdown(!!outputMarkdown)
   const url = `https://socket.dev/npm/package/${pkgName}/overview/${pkgVersion}`
 
   console.log('\nDetailed info on socket.dev: ' + format.hyperlink(`${pkgName} v${pkgVersion}`, url, { fallbackToUrl: true }))
-
   if (!outputMarkdown) {
     console.log(chalk.dim('\nOr rerun', chalk.italic(name), 'using the', chalk.italic('--json'), 'flag to get full JSON output'))
   }
 }
-
-/** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
-export const info = { description, run }

--- a/lib/commands/info/index.js
+++ b/lib/commands/info/index.js
@@ -7,8 +7,8 @@ import { ErrorWithCause } from 'pony-cause'
 
 import { ChalkOrMarkdown } from '../../utils/chalk-markdown.js'
 import { AuthError, InputError } from '../../utils/errors.js'
+import { getSeveritySummary } from '../../utils/format-issues.js'
 import { printFlagList } from '../../utils/formatting.js'
-import { stringJoinWithSeparateFinalSeparator } from '../../utils/misc.js'
 import { setupSdk } from '../../utils/sdk.js'
 
 const description = 'Look up info regarding a package'
@@ -87,7 +87,7 @@ const run = async (argv, importMeta, { parentName }) => {
 
   const spinner = ora(`Looking up data for version ${pkgVersion} of ${pkgName}`).start()
 
-  /** @type {Awaited<ReturnType<import('@socketsecurity/sdk').SocketSdk["getIssuesByNPMPackage"]>>} */
+  /** @type {Awaited<ReturnType<typeof socketSdk.getIssuesByNPMPackage>>} */
   let result
 
   try {
@@ -106,34 +106,12 @@ const run = async (argv, importMeta, { parentName }) => {
     process.exit(1)
   }
 
-  const data = result.data
-
-  /** @typedef {(typeof data)[number]["value"] extends infer U | undefined ? U : never} SocketSdkIssue */
-  /** @type {Record<SocketSdkIssue["severity"], number>} */
-  const severityCount = { low: 0, middle: 0, high: 0, critical: 0 }
-  for (const issue of data) {
-    const value = issue.value
-
-    if (!value) {
-      continue
-    }
-
-    if (severityCount[value.severity] !== undefined) {
-      severityCount[value.severity] += 1
-    }
-  }
-
-  const issueSummary = stringJoinWithSeparateFinalSeparator([
-    severityCount.critical ? severityCount.critical + ' critical' : undefined,
-    severityCount.high ? severityCount.high + ' high' : undefined,
-    severityCount.middle ? severityCount.middle + ' middle' : undefined,
-    severityCount.low ? severityCount.low + ' low' : undefined,
-  ])
+  const issueSummary = getSeveritySummary(result.data)
 
   spinner.succeed(`Found ${issueSummary || 'no'} issues for version ${pkgVersion} of ${pkgName}`)
 
   if (outputJson) {
-    console.log(JSON.stringify(data, undefined, 2))
+    console.log(JSON.stringify(result.data, undefined, 2))
     return
   }
 

--- a/lib/commands/report/create.js
+++ b/lib/commands/report/create.js
@@ -14,20 +14,37 @@ import { printFlagList } from '../../utils/formatting.js'
 import { createDebugLogger } from '../../utils/misc.js'
 import { setupSdk } from '../../utils/sdk.js'
 import { isErrnoException } from '../../utils/type-helpers.js'
+import { fetchReportData, formatReportDataOutput } from './view.js'
 
 /** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
 export const create = {
   description: 'Create a project report',
   async run (argv, importMeta, { parentName }) {
-    const name = parentName + ' view'
+    const name = parentName + ' create'
 
     const input = await setupCommand(name, create.description, argv, importMeta)
 
     if (input) {
-      const { cwd, debugLog, dryRun, outputJson, outputMarkdown, packagePaths } = input
+      const {
+        cwd,
+        debugLog,
+        dryRun,
+        outputJson,
+        outputMarkdown,
+        packagePaths,
+        view,
+      } = input
+
       const result = input && await createReport(packagePaths, { cwd, debugLog, dryRun })
 
-      if (result) {
+      if (result && view) {
+        const reportId = result.data.id
+        const reportResult = input && await fetchReportData(reportId)
+
+        if (reportResult) {
+          formatReportDataOutput(reportResult.data, { name, outputJson, outputMarkdown, reportId })
+        }
+      } else if (result) {
         formatReportCreationOutput(result.data, { outputJson, outputMarkdown })
       }
     }
@@ -41,7 +58,7 @@ export const create = {
  * @param {string} description
  * @param {readonly string[]} argv
  * @param {ImportMeta} importMeta
- * @returns {Promise<void|{ cwd: string, debugLog: typeof console.error, dryRun: boolean, outputJson: boolean, outputMarkdown: boolean, packagePaths: string[] }>}
+ * @returns {Promise<void|{ cwd: string, debugLog: typeof console.error, dryRun: boolean, outputJson: boolean, outputMarkdown: boolean, packagePaths: string[], view: boolean }>}
  */
 async function setupCommand (name, description, argv, importMeta) {
   const cli = meow(`
@@ -54,6 +71,7 @@ async function setupCommand (name, description, argv, importMeta) {
         '--dry-run': 'Only output what will be done without actually doing it',
         '--json': 'Output result as json',
         '--markdown': 'Output result as markdown',
+        '--view': 'Will wait for and return the created report'
       }, 6)}
 
     Examples
@@ -84,6 +102,11 @@ async function setupCommand (name, description, argv, importMeta) {
         alias: 'm',
         default: false,
       },
+      view: {
+        type: 'boolean',
+        alias: 'v',
+        default: false,
+      },
     }
   })
 
@@ -91,6 +114,7 @@ async function setupCommand (name, description, argv, importMeta) {
     dryRun,
     json: outputJson,
     markdown: outputMarkdown,
+    view,
   } = cli.flags
 
   if (!cli.input[0]) {
@@ -109,7 +133,8 @@ async function setupCommand (name, description, argv, importMeta) {
     dryRun,
     outputJson,
     outputMarkdown,
-    packagePaths
+    packagePaths,
+    view,
   }
 }
 

--- a/lib/commands/report/create.js
+++ b/lib/commands/report/create.js
@@ -3,24 +3,47 @@
 import { stat } from 'node:fs/promises'
 import path from 'node:path'
 
-import chalk from 'chalk'
 import meow from 'meow'
 import ora from 'ora'
 import { ErrorWithCause } from 'pony-cause'
 
+import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api-helpers.js'
 import { ChalkOrMarkdown, logSymbols } from '../../utils/chalk-markdown.js'
-import { AuthError, InputError } from '../../utils/errors.js'
+import { InputError } from '../../utils/errors.js'
 import { printFlagList } from '../../utils/formatting.js'
 import { createDebugLogger } from '../../utils/misc.js'
 import { setupSdk } from '../../utils/sdk.js'
 import { isErrnoException } from '../../utils/type-helpers.js'
 
-const description = 'Create a project report'
+/** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
+export const create = {
+  description: 'Create a project report',
+  async run (argv, importMeta, { parentName }) {
+    const name = parentName + ' view'
 
-/** @type {import('../../utils/meow-with-subcommands').CliSubcommandRun} */
-const run = async (argv, importMeta, { parentName }) => {
-  const name = parentName + ' create'
+    const input = await setupCommand(name, create.description, argv, importMeta)
 
+    if (input) {
+      const { cwd, debugLog, dryRun, outputJson, outputMarkdown, packagePaths } = input
+      const result = input && await createReport(packagePaths, { cwd, debugLog, dryRun })
+
+      if (result) {
+        formatReportCreationOutput(result.data, { outputJson, outputMarkdown })
+      }
+    }
+  }
+}
+
+// Internal functions
+
+/**
+ * @param {string} name
+ * @param {string} description
+ * @param {readonly string[]} argv
+ * @param {ImportMeta} importMeta
+ * @returns {Promise<void|{ cwd: string, debugLog: typeof console.error, dryRun: boolean, outputJson: boolean, outputMarkdown: boolean, packagePaths: string[] }>}
+ */
+async function setupCommand (name, description, argv, importMeta) {
   const cli = meow(`
     Usage
       $ ${name} <paths-to-package-folders-and-files>
@@ -80,6 +103,22 @@ const run = async (argv, importMeta, { parentName }) => {
   const cwd = process.cwd()
   const packagePaths = await resolvePackagePaths(cwd, cli.input)
 
+  return {
+    cwd,
+    debugLog,
+    dryRun,
+    outputJson,
+    outputMarkdown,
+    packagePaths
+  }
+}
+
+/**
+ * @param {string[]} packagePaths
+ * @param {{ cwd: string, debugLog: typeof console.error, dryRun: boolean }} context
+ * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'createReport'>>}
+ */
+async function createReport (packagePaths, { cwd, debugLog, dryRun }) {
   debugLog(`${logSymbols.info} Uploading:`, packagePaths.join(`\n${logSymbols.info} Uploading:`))
 
   if (dryRun) {
@@ -87,42 +126,35 @@ const run = async (argv, importMeta, { parentName }) => {
   }
 
   const socketSdk = await setupSdk()
-
   const spinner = ora(`Creating report with ${packagePaths.length} package files`).start()
-
-  /** @type {Awaited<ReturnType<typeof socketSdk.createReportFromFilePaths>>} */
-  let result
-
-  try {
-    result = await socketSdk.createReportFromFilePaths(packagePaths, cwd)
-  } catch (cause) {
-    spinner.fail()
-    throw new ErrorWithCause('Failed creating report', { cause })
-  }
+  const result = await handleApiCall(socketSdk.createReportFromFilePaths(packagePaths, cwd), spinner, 'creating report')
 
   if (result.success === false) {
-    if (result.status === 401 || result.status === 403) {
-      spinner.stop()
-      throw new AuthError(result.error.message)
-    }
-    spinner.fail(chalk.white.bgRed('API returned an error:') + ' ' + result.error.message)
-    process.exit(1)
+    return handleUnsuccessfulApiResponse(result, spinner)
   }
+
+  // Conclude the status of the API call
 
   spinner.succeed()
 
+  return result
+}
+
+/**
+ * @param {import('@socketsecurity/sdk').SocketSdkReturnType<'createReport'>["data"]} data
+ * @param {{ outputJson: boolean, outputMarkdown: boolean }} context
+ * @returns {void}
+ */
+function formatReportCreationOutput (data, { outputJson, outputMarkdown }) {
   if (outputJson) {
-    console.log(JSON.stringify(result.data, undefined, 2))
+    console.log(JSON.stringify(data, undefined, 2))
     return
   }
 
   const format = new ChalkOrMarkdown(!!outputMarkdown)
 
-  console.log('\nNew report: ' + format.hyperlink(result.data.id, result.data.url, { fallbackToUrl: true }))
+  console.log('\nNew report: ' + format.hyperlink(data.id, data.url, { fallbackToUrl: true }))
 }
-
-/** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
-export const create = { description, run }
 
 // TODO: Add globbing support with support for ignoring, as a "./**/package.json" in a project also traverses eg. node_modules
 /**

--- a/lib/commands/report/index.js
+++ b/lib/commands/report/index.js
@@ -1,5 +1,6 @@
 import { meowWithSubcommands } from '../../utils/meow-with-subcommands.js'
 import { create } from './create.js'
+import { view } from './view.js'
 
 const description = 'Project report related commands'
 
@@ -10,6 +11,7 @@ export const report = {
     await meowWithSubcommands(
       {
         create,
+        view,
       },
       {
         argv,

--- a/lib/commands/report/view.js
+++ b/lib/commands/report/view.js
@@ -100,7 +100,7 @@ function setupCommand (name, description, argv, importMeta) {
  * @param {string} reportId
  * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'getReport'>>}
  */
-async function fetchReportData (reportId) {
+export async function fetchReportData (reportId) {
   // Do the API call
 
   const socketSdk = await setupSdk()
@@ -124,7 +124,7 @@ async function fetchReportData (reportId) {
  * @param {{ name: string, outputJson: boolean, outputMarkdown: boolean, reportId: string }} context
  * @returns {void}
  */
-function formatReportDataOutput (data, { name, outputJson, outputMarkdown, reportId }) {
+export function formatReportDataOutput (data, { name, outputJson, outputMarkdown, reportId }) {
   // If JSON, output and return...
 
   if (outputJson) {

--- a/lib/commands/report/view.js
+++ b/lib/commands/report/view.js
@@ -1,0 +1,144 @@
+/* eslint-disable no-console */
+
+import chalk from 'chalk'
+import meow from 'meow'
+import ora from 'ora'
+
+import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api-helpers.js'
+import { ChalkOrMarkdown } from '../../utils/chalk-markdown.js'
+import { InputError } from '../../utils/errors.js'
+import { getSeveritySummary } from '../../utils/format-issues.js'
+import { printFlagList } from '../../utils/formatting.js'
+import { setupSdk } from '../../utils/sdk.js'
+
+/** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
+export const view = {
+  description: 'View a project report',
+  async run (argv, importMeta, { parentName }) {
+    const name = parentName + ' view'
+
+    const input = setupCommand(name, view.description, argv, importMeta)
+    const result = input && await fetchReportData(input.reportId)
+
+    if (result) {
+      formatReportDataOutput(result.data, { name, ...input })
+    }
+  }
+}
+
+// Internal functions
+
+/**
+ * @param {string} name
+ * @param {string} description
+ * @param {readonly string[]} argv
+ * @param {ImportMeta} importMeta
+ * @returns {void|{ outputJson: boolean, outputMarkdown: boolean, reportId: string }}
+ */
+function setupCommand (name, description, argv, importMeta) {
+  // FIXME: Add examples
+  const cli = meow(`
+    Usage
+      $ ${name} <report-identifier>
+
+    Options
+      ${printFlagList({
+        '--json': 'Output result as json',
+        '--markdown': 'Output result as markdown',
+      }, 6)}
+  `, {
+    argv,
+    description,
+    importMeta,
+    flags: {
+      debug: {
+        type: 'boolean',
+        alias: 'd',
+        default: false,
+      },
+      json: {
+        type: 'boolean',
+        alias: 'j',
+        default: false,
+      },
+      markdown: {
+        type: 'boolean',
+        alias: 'm',
+        default: false,
+      },
+    }
+  })
+
+  // Extract the input
+
+  const {
+    json: outputJson,
+    markdown: outputMarkdown,
+  } = cli.flags
+
+  const [reportId, ...extraInput] = cli.input
+
+  if (!reportId) {
+    cli.showHelp()
+    return
+  }
+
+  // Validate the input
+
+  if (extraInput.length) {
+    throw new InputError(`Can only handle a single report ID at a time, but got ${cli.input.length} report ID:s: ${cli.input.join(', ')}`)
+  }
+
+  return {
+    outputJson,
+    outputMarkdown,
+    reportId,
+  }
+}
+
+/**
+ * @param {string} reportId
+ * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'getReport'>>}
+ */
+async function fetchReportData (reportId) {
+  // Do the API call
+
+  const socketSdk = await setupSdk()
+  const spinner = ora(`Fetching report with ID ${reportId}`).start()
+  const result = await handleApiCall(socketSdk.getReport(reportId), spinner, 'fetching report')
+
+  if (result.success === false) {
+    return handleUnsuccessfulApiResponse(result, spinner)
+  }
+
+  // Conclude the status of the API call
+
+  const issueSummary = getSeveritySummary(result.data.issues)
+  spinner.succeed(`Report contains ${issueSummary || 'no'} issues`)
+
+  return result
+}
+
+/**
+ * @param {import('@socketsecurity/sdk').SocketSdkReturnType<'getReport'>["data"]} data
+ * @param {{ name: string, outputJson: boolean, outputMarkdown: boolean, reportId: string }} context
+ * @returns {void}
+ */
+function formatReportDataOutput (data, { name, outputJson, outputMarkdown, reportId }) {
+  // If JSON, output and return...
+
+  if (outputJson) {
+    console.log(JSON.stringify(data, undefined, 2))
+    return
+  }
+
+  // ...else do the CLI / Markdown output dance
+
+  const format = new ChalkOrMarkdown(!!outputMarkdown)
+  const url = `https://socket.dev/npm/reports/${encodeURIComponent(reportId)}`
+
+  console.log('\nDetailed info on socket.dev: ' + format.hyperlink(reportId, url, { fallbackToUrl: true }))
+  if (!outputMarkdown) {
+    console.log(chalk.dim('\nOr rerun', chalk.italic(name), 'using the', chalk.italic('--json'), 'flag to get full JSON output'))
+  }
+}

--- a/lib/utils/api-helpers.js
+++ b/lib/utils/api-helpers.js
@@ -1,0 +1,43 @@
+import chalk from 'chalk'
+import { ErrorWithCause } from 'pony-cause'
+
+import { AuthError } from './errors.js'
+
+/**
+ * @template T
+ * @param {import('@socketsecurity/sdk').SocketSdkErrorType<T>} result
+ * @param {import('ora').Ora} spinner
+ * @returns {void}
+ */
+export function handleUnsuccessfulApiResponse (result, spinner) {
+  const resultError = 'error' in result && result.error && typeof result.error === 'object' ? result.error : {}
+  const message = 'message' in resultError && typeof resultError.message === 'string' ? resultError.message : 'No error message returned'
+
+  if (result.status === 401 || result.status === 403) {
+    spinner.stop()
+    throw new AuthError(message)
+  }
+  spinner.fail(chalk.white.bgRed('API returned an error:') + ' ' + message)
+  process.exit(1)
+}
+
+/**
+ * @template T
+ * @param {Promise<T>} value
+ * @param {import('ora').Ora} spinner
+ * @param {string} description
+ * @returns {Promise<T>}
+ */
+export async function handleApiCall (value, spinner, description) {
+  /** @type {T} */
+  let result
+
+  try {
+    result = await value
+  } catch (cause) {
+    spinner.fail()
+    throw new ErrorWithCause(`Failed ${description}`, { cause })
+  }
+
+  return result
+}

--- a/lib/utils/format-issues.js
+++ b/lib/utils/format-issues.js
@@ -1,0 +1,44 @@
+/** @typedef {import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>['data']} SocketIssueList */
+/** @typedef {SocketIssueList[number]['value'] extends infer U | undefined ? U : never} SocketIssue */
+
+import { stringJoinWithSeparateFinalSeparator } from './misc.js'
+
+/**
+ * @param {SocketIssueList} issues
+ * @returns {Record<SocketIssue['severity'], number>}
+ */
+function getSeverityCount (issues) {
+  /** @type {Record<SocketIssue['severity'], number>} */
+  const severityCount = { low: 0, middle: 0, high: 0, critical: 0 }
+
+  for (const issue of issues) {
+    const value = issue.value
+
+    if (!value) {
+      continue
+    }
+
+    if (severityCount[value.severity] !== undefined) {
+      severityCount[value.severity] += 1
+    }
+  }
+
+  return severityCount
+}
+
+/**
+ * @param {SocketIssueList} issues
+ * @returns {string}
+ */
+export function getSeveritySummary (issues) {
+  const severityCount = getSeverityCount(issues)
+
+  const issueSummary = stringJoinWithSeparateFinalSeparator([
+    severityCount.critical ? severityCount.critical + ' critical' : undefined,
+    severityCount.high ? severityCount.high + ' high' : undefined,
+    severityCount.middle ? severityCount.middle + ' middle' : undefined,
+    severityCount.low ? severityCount.low + ' low' : undefined,
+  ])
+
+  return issueSummary
+}


### PR DESCRIPTION
This adds a first version of a `socket report view` command + enables one to use it directly with `socket report create` through the `--view` flag, waiting for the report to be created first.

The output for the report is pretty much the same as for the `socket info` command, reusing the same formatting.

The `--view` flag reuses the relevant parts of the `socket report view` command and gets fed the relevant flags of the `socket report create` command (the `--json` and `--markdown` flags) – thus making it possible to directly forward the full JSON response from the API to somewhere else.