### PR TITLE
Add update notifier

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,8 +8,12 @@ import * as cliCommands from './lib/commands/index.js'
 import { logSymbols } from './lib/utils/chalk-markdown.js'
 import { AuthError, InputError } from './lib/utils/errors.js'
 import { meowWithSubcommands } from './lib/utils/meow-with-subcommands.js'
+import { updateNotifier } from './lib/utils/update-notifier.js'
 
 // TODO: Add autocompletion using https://www.npmjs.com/package/omelette
+
+// Once per day this will check npm for an update of the module
+await updateNotifier()
 
 try {
   await meowWithSubcommands(

--- a/lib/utils/update-notifier.js
+++ b/lib/utils/update-notifier.js
@@ -1,0 +1,9 @@
+import { readFile } from 'node:fs/promises'
+
+import simpleUpdateNotifier from 'simple-update-notifier'
+
+/** @returns {Promise<void>} */
+export async function updateNotifier () {
+  const pkg = JSON.parse(await readFile(new URL('../../package.json', import.meta.url), 'utf8'))
+  await simpleUpdateNotifier({ pkg })
+}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ora": "^6.1.2",
     "pony-cause": "^2.1.8",
     "prompts": "^2.4.2",
+    "simple-update-notifier": "^1.0.8",
     "terminal-link": "^3.0.0"
   }
 }


### PR DESCRIPTION
Global npm scripts can often be forgotten to be updated, so this PR adds the same update notification module that `nodemon` uses, `simple-update-notifier`, and lets it check npm for an update once per day.

Waiting for https://github.com/alexbrazier/simple-update-notifier/pull/16 before merging.