### PR TITLE
Add `update-notifier`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,8 +8,11 @@ import * as cliCommands from './lib/commands/index.js'
 import { logSymbols } from './lib/utils/chalk-markdown.js'
 import { AuthError, InputError } from './lib/utils/errors.js'
 import { meowWithSubcommands } from './lib/utils/meow-with-subcommands.js'
+import { initUpdateNotifier } from './lib/utils/update-notifier.js'
 
 // TODO: Add autocompletion using https://www.npmjs.com/package/omelette
+
+initUpdateNotifier()
 
 try {
   await meowWithSubcommands(

--- a/lib/utils/update-notifier.js
+++ b/lib/utils/update-notifier.js
@@ -1,0 +1,15 @@
+import { readFile } from 'node:fs/promises'
+
+import updateNotifier from 'update-notifier'
+
+/** @returns {void} */
+export function initUpdateNotifier () {
+  readFile(new URL('../../package.json', import.meta.url), 'utf8')
+    .then(rawPkg => {
+      const pkg = JSON.parse(rawPkg)
+      updateNotifier({ pkg }).notify()
+    })
+    .catch(() => {
+      // Fail silently if package.json could not be read or parsed
+    })
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/mocha": "^10.0.0",
     "@types/node": "^14.18.31",
     "@types/prompts": "^2.4.1",
+    "@types/update-notifier": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",
     "c8": "^7.12.0",
@@ -77,6 +78,7 @@
     "ora": "^6.1.2",
     "pony-cause": "^2.1.8",
     "prompts": "^2.4.2",
-    "terminal-link": "^3.0.0"
+    "terminal-link": "^3.0.0",
+    "update-notifier": "^6.0.2"
   }
 }


### PR DESCRIPTION
Alternative to #8 with a module that pulls in more dependencies, but which also have more features and eg. defers printing the result until the script quits, disables itself on CI, always prints to stderr etc

Has quite a few more users as well. A good first step to try this out probably.