### PR TITLE
Add `--strict` and `--all` to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ socket report view QXU8PmK7LfH608RAwfIKdbcHgwEd_ZeWJ9QEGv05FJUQ
 * `--json` - outputs result as json which you can then pipe into [`jq`](https://stedolan.github.io/jq/) and other tools
 * `--markdown` - outputs result as markdown which you can then copy into an issue, PR or even chat
 
+## Strictness flags
+
+* `--all` - by default only `high` and `critical` issues are included, by setting this flag all issues will be included
+* `--strict` - when set, exits with an error code if any issues were found
+
 ### Other flags
 
 * `--dry-run` - like all CLI tools that perform an action should have, we have a dry run flag. Eg. `socket report create` supports running the command without actually uploading anything

--- a/lib/commands/info/index.js
+++ b/lib/commands/info/index.js
@@ -7,8 +7,9 @@ import ora from 'ora'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api-helpers.js'
 import { ChalkOrMarkdown } from '../../utils/chalk-markdown.js'
 import { InputError } from '../../utils/errors.js'
-import { getSeveritySummary } from '../../utils/format-issues.js'
+import { getSeverityCount, formatSeverityCount } from '../../utils/format-issues.js'
 import { printFlagList } from '../../utils/formatting.js'
+import { objectSome } from '../../utils/misc.js'
 import { setupSdk } from '../../utils/sdk.js'
 
 /** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
@@ -18,10 +19,10 @@ export const info = {
     const name = parentName + ' info'
 
     const input = setupCommand(name, info.description, argv, importMeta)
-    const result = input && await fetchPackageData(input.pkgName, input.pkgVersion)
+    const packageData = input && await fetchPackageData(input.pkgName, input.pkgVersion, input)
 
-    if (result) {
-      formatPackageDataOutput(result.data, { name, ...input })
+    if (packageData) {
+      formatPackageDataOutput(packageData, { name, ...input })
     }
   }
 }
@@ -29,21 +30,33 @@ export const info = {
 // Internal functions
 
 /**
+ * @typedef CommandContext
+ * @property {boolean} includeAllIssues
+ * @property {boolean} outputJson
+ * @property {boolean} outputMarkdown
+ * @property {string} pkgName
+ * @property {string} pkgVersion
+ * @property {boolean} strict
+ */
+
+/**
  * @param {string} name
  * @param {string} description
  * @param {readonly string[]} argv
  * @param {ImportMeta} importMeta
- * @returns {void|{ outputJson: boolean, outputMarkdown: boolean, pkgName: string, pkgVersion: string }}
+ * @returns {void|CommandContext}
  */
- function setupCommand (name, description, argv, importMeta) {
+function setupCommand (name, description, argv, importMeta) {
   const cli = meow(`
     Usage
       $ ${name} <name>
 
     Options
       ${printFlagList({
+        '--all': 'Include all issues',
         '--json': 'Output result as json',
         '--markdown': 'Output result as markdown',
+        '--strict': 'Exits with an error code if any matching issues are found',
       }, 6)}
 
     Examples
@@ -54,6 +67,10 @@ export const info = {
     description,
     importMeta,
     flags: {
+      all: {
+        type: 'boolean',
+        default: false,
+      },
       json: {
         type: 'boolean',
         alias: 'j',
@@ -64,12 +81,18 @@ export const info = {
         alias: 'm',
         default: false,
       },
+      strict: {
+        type: 'boolean',
+        default: false,
+      },
     }
   })
 
   const {
+    all: includeAllIssues,
     json: outputJson,
     markdown: outputMarkdown,
+    strict,
   } = cli.flags
 
   if (cli.input.length > 1) {
@@ -97,19 +120,28 @@ export const info = {
   }
 
   return {
+    includeAllIssues,
     outputJson,
     outputMarkdown,
     pkgName,
-    pkgVersion
+    pkgVersion,
+    strict,
   }
 }
 
 /**
+ * @typedef PackageData
+ * @property {import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>["data"]} data
+ * @property {Record<import('../../utils/format-issues').SocketIssue['severity'], number>} severityCount
+ */
+
+/**
  * @param {string} pkgName
  * @param {string} pkgVersion
- * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>>}
+ * @param {Pick<CommandContext, 'includeAllIssues' | 'strict'>} context
+ * @returns {Promise<void|PackageData>}
  */
-async function fetchPackageData (pkgName, pkgVersion) {
+async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict }) {
   const socketSdk = await setupSdk()
   const spinner = ora(`Looking up data for version ${pkgVersion} of ${pkgName}`).start()
   const result = await handleApiCall(socketSdk.getIssuesByNPMPackage(pkgName, pkgVersion), spinner, 'looking up package')
@@ -120,32 +152,40 @@ async function fetchPackageData (pkgName, pkgVersion) {
 
   // Conclude the status of the API call
 
-  const issueSummary = getSeveritySummary(result.data)
-  spinner.succeed(`Found ${issueSummary || 'no'} issues for version ${pkgVersion} of ${pkgName}`)
+  const severityCount = getSeverityCount(result.data, includeAllIssues ? undefined : 'high')
 
-  return result
+  if (objectSome(severityCount)) {
+    const issueSummary = formatSeverityCount(severityCount)
+    spinner[strict ? 'fail' : 'succeed'](`Package has these issues: ${issueSummary}`)
+  } else {
+    spinner.succeed('Package has no issues')
+  }
+
+  return {
+    data: result.data,
+    severityCount,
+  }
 }
 
 /**
- * @param {import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>["data"]} data
- * @param {{ name: string, outputJson: boolean, outputMarkdown: boolean, pkgName: string, pkgVersion: string }} context
+ * @param {PackageData} packageData
+ * @param {{ name: string } & CommandContext} context
  * @returns {void}
  */
- function formatPackageDataOutput (data, { name, outputJson, outputMarkdown, pkgName, pkgVersion }) {
-  // If JSON, output and return...
-
+ function formatPackageDataOutput ({ data, severityCount }, { name, outputJson, outputMarkdown, pkgName, pkgVersion, strict }) {
   if (outputJson) {
     console.log(JSON.stringify(data, undefined, 2))
-    return
+  } else {
+    const format = new ChalkOrMarkdown(!!outputMarkdown)
+    const url = `https://socket.dev/npm/package/${pkgName}/overview/${pkgVersion}`
+
+    console.log('\nDetailed info on socket.dev: ' + format.hyperlink(`${pkgName} v${pkgVersion}`, url, { fallbackToUrl: true }))
+    if (!outputMarkdown) {
+      console.log(chalk.dim('\nOr rerun', chalk.italic(name), 'using the', chalk.italic('--json'), 'flag to get full JSON output'))
+    }
   }
 
-  // ...else do the CLI / Markdown output dance
-
-  const format = new ChalkOrMarkdown(!!outputMarkdown)
-  const url = `https://socket.dev/npm/package/${pkgName}/overview/${pkgVersion}`
-
-  console.log('\nDetailed info on socket.dev: ' + format.hyperlink(`${pkgName} v${pkgVersion}`, url, { fallbackToUrl: true }))
-  if (!outputMarkdown) {
-    console.log(chalk.dim('\nOr rerun', chalk.italic(name), 'using the', chalk.italic('--json'), 'flag to get full JSON output'))
+  if (strict && objectSome(severityCount)) {
+    process.exit(1)
   }
 }

--- a/lib/commands/report/create.js
+++ b/lib/commands/report/create.js
@@ -29,9 +29,11 @@ export const create = {
         cwd,
         debugLog,
         dryRun,
+        includeAllIssues,
         outputJson,
         outputMarkdown,
         packagePaths,
+        strict,
         view,
       } = input
 
@@ -39,10 +41,10 @@ export const create = {
 
       if (result && view) {
         const reportId = result.data.id
-        const reportResult = input && await fetchReportData(reportId)
+        const reportData = input && await fetchReportData(reportId, { includeAllIssues, strict })
 
-        if (reportResult) {
-          formatReportDataOutput(reportResult.data, { name, outputJson, outputMarkdown, reportId })
+        if (reportData) {
+          formatReportDataOutput(reportData, { includeAllIssues, name, outputJson, outputMarkdown, reportId, strict })
         }
       } else if (result) {
         formatReportCreationOutput(result.data, { outputJson, outputMarkdown })
@@ -54,11 +56,24 @@ export const create = {
 // Internal functions
 
 /**
+ * @typedef CommandContext
+ * @property {string} cwd
+ * @property {typeof console.error} debugLog
+ * @property {boolean} dryRun
+ * @property {boolean} includeAllIssues
+ * @property {boolean} outputJson
+ * @property {boolean} outputMarkdown
+ * @property {string[]} packagePaths
+ * @property {boolean} strict
+ * @property {boolean} view
+ */
+
+/**
  * @param {string} name
  * @param {string} description
  * @param {readonly string[]} argv
  * @param {ImportMeta} importMeta
- * @returns {Promise<void|{ cwd: string, debugLog: typeof console.error, dryRun: boolean, outputJson: boolean, outputMarkdown: boolean, packagePaths: string[], view: boolean }>}
+ * @returns {Promise<void|CommandContext>}
  */
 async function setupCommand (name, description, argv, importMeta) {
   const cli = meow(`
@@ -67,10 +82,12 @@ async function setupCommand (name, description, argv, importMeta) {
 
     Options
       ${printFlagList({
+        '--all': 'Include all issues',
         '--debug': 'Output debug information',
         '--dry-run': 'Only output what will be done without actually doing it',
         '--json': 'Output result as json',
         '--markdown': 'Output result as markdown',
+        '--strict': 'Exits with an error code if any matching issues are found',
         '--view': 'Will wait for and return the created report'
       }, 6)}
 
@@ -84,6 +101,10 @@ async function setupCommand (name, description, argv, importMeta) {
     description,
     importMeta,
     flags: {
+      all: {
+        type: 'boolean',
+        default: false,
+      },
       debug: {
         type: 'boolean',
         alias: 'd',
@@ -103,6 +124,10 @@ async function setupCommand (name, description, argv, importMeta) {
         alias: 'm',
         default: false,
       },
+      strict: {
+        type: 'boolean',
+        default: false,
+      },
       view: {
         type: 'boolean',
         alias: 'v',
@@ -112,9 +137,11 @@ async function setupCommand (name, description, argv, importMeta) {
   })
 
   const {
+    all: includeAllIssues,
     dryRun,
     json: outputJson,
     markdown: outputMarkdown,
+    strict,
     view,
   } = cli.flags
 
@@ -132,16 +159,18 @@ async function setupCommand (name, description, argv, importMeta) {
     cwd,
     debugLog,
     dryRun,
+    includeAllIssues,
     outputJson,
     outputMarkdown,
     packagePaths,
+    strict,
     view,
   }
 }
 
 /**
  * @param {string[]} packagePaths
- * @param {{ cwd: string, debugLog: typeof console.error, dryRun: boolean }} context
+ * @param {Pick<CommandContext, 'cwd' | 'debugLog' | 'dryRun'>} context
  * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'createReport'>>}
  */
 async function createReport (packagePaths, { cwd, debugLog, dryRun }) {
@@ -168,7 +197,7 @@ async function createReport (packagePaths, { cwd, debugLog, dryRun }) {
 
 /**
  * @param {import('@socketsecurity/sdk').SocketSdkReturnType<'createReport'>["data"]} data
- * @param {{ outputJson: boolean, outputMarkdown: boolean }} context
+ * @param {Pick<CommandContext, 'outputJson' | 'outputMarkdown'>} context
  * @returns {void}
  */
 function formatReportCreationOutput (data, { outputJson, outputMarkdown }) {

--- a/lib/commands/report/view.js
+++ b/lib/commands/report/view.js
@@ -7,8 +7,9 @@ import ora from 'ora'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api-helpers.js'
 import { ChalkOrMarkdown } from '../../utils/chalk-markdown.js'
 import { InputError } from '../../utils/errors.js'
-import { getSeveritySummary } from '../../utils/format-issues.js'
+import { getSeverityCount, formatSeverityCount } from '../../utils/format-issues.js'
 import { printFlagList } from '../../utils/formatting.js'
+import { objectSome } from '../../utils/misc.js'
 import { setupSdk } from '../../utils/sdk.js'
 
 /** @type {import('../../utils/meow-with-subcommands').CliSubcommand} */
@@ -18,22 +19,32 @@ export const view = {
     const name = parentName + ' view'
 
     const input = setupCommand(name, view.description, argv, importMeta)
-    const result = input && await fetchReportData(input.reportId)
+    const result = input && await fetchReportData(input.reportId, input)
 
     if (result) {
-      formatReportDataOutput(result.data, { name, ...input })
+      formatReportDataOutput(result, { name, ...input })
     }
   }
 }
 
 // Internal functions
 
+// TODO: Share more of the flag setup inbetween the commands
+/**
+ * @typedef CommandContext
+ * @property {boolean} includeAllIssues
+ * @property {boolean} outputJson
+ * @property {boolean} outputMarkdown
+ * @property {string} reportId
+ * @property {boolean} strict
+ */
+
 /**
  * @param {string} name
  * @param {string} description
  * @param {readonly string[]} argv
  * @param {ImportMeta} importMeta
- * @returns {void|{ outputJson: boolean, outputMarkdown: boolean, reportId: string }}
+ * @returns {void|CommandContext}
  */
 function setupCommand (name, description, argv, importMeta) {
   const cli = meow(`
@@ -42,8 +53,10 @@ function setupCommand (name, description, argv, importMeta) {
 
     Options
       ${printFlagList({
+        '--all': 'Include all issues',
         '--json': 'Output result as json',
         '--markdown': 'Output result as markdown',
+        '--strict': 'Exits with an error code if any matching issues are found',
       }, 6)}
 
     Examples
@@ -53,9 +66,8 @@ function setupCommand (name, description, argv, importMeta) {
     description,
     importMeta,
     flags: {
-      debug: {
+      all: {
         type: 'boolean',
-        alias: 'd',
         default: false,
       },
       json: {
@@ -68,14 +80,20 @@ function setupCommand (name, description, argv, importMeta) {
         alias: 'm',
         default: false,
       },
+      strict: {
+        type: 'boolean',
+        default: false,
+      },
     }
   })
 
   // Extract the input
 
   const {
+    all: includeAllIssues,
     json: outputJson,
     markdown: outputMarkdown,
+    strict,
   } = cli.flags
 
   const [reportId, ...extraInput] = cli.input
@@ -92,17 +110,26 @@ function setupCommand (name, description, argv, importMeta) {
   }
 
   return {
+    includeAllIssues,
     outputJson,
     outputMarkdown,
     reportId,
+    strict,
   }
 }
 
 /**
- * @param {string} reportId
- * @returns {Promise<void|import('@socketsecurity/sdk').SocketSdkReturnType<'getReport'>>}
+ * @typedef ReportData
+ * @property {import('@socketsecurity/sdk').SocketSdkReturnType<'getReport'>["data"]} data
+ * @property {Record<import('../../utils/format-issues').SocketIssue['severity'], number>} severityCount
  */
-export async function fetchReportData (reportId) {
+
+/**
+ * @param {string} reportId
+ * @param {Pick<CommandContext, 'includeAllIssues' | 'strict'>} context
+ * @returns {Promise<void|ReportData>}
+ */
+export async function fetchReportData (reportId, { includeAllIssues, strict }) {
   // Do the API call
 
   const socketSdk = await setupSdk()
@@ -115,32 +142,40 @@ export async function fetchReportData (reportId) {
 
   // Conclude the status of the API call
 
-  const issueSummary = getSeveritySummary(result.data.issues)
-  spinner.succeed(`Report contains ${issueSummary || 'no'} issues`)
+  const severityCount = getSeverityCount(result.data.issues, includeAllIssues ? undefined : 'high')
 
-  return result
+  if (objectSome(severityCount)) {
+    const issueSummary = formatSeverityCount(severityCount)
+    spinner[strict ? 'fail' : 'succeed'](`Report has these issues: ${issueSummary}`)
+  } else {
+    spinner.succeed('Report has no issues')
+  }
+
+  return {
+    data: result.data,
+    severityCount,
+  }
 }
 
 /**
- * @param {import('@socketsecurity/sdk').SocketSdkReturnType<'getReport'>["data"]} data
- * @param {{ name: string, outputJson: boolean, outputMarkdown: boolean, reportId: string }} context
+ * @param {ReportData} reportData
+ * @param {{ name: string } & CommandContext} context
  * @returns {void}
  */
-export function formatReportDataOutput (data, { name, outputJson, outputMarkdown, reportId }) {
-  // If JSON, output and return...
-
+export function formatReportDataOutput ({ data, severityCount }, { name, outputJson, outputMarkdown, reportId, strict }) {
   if (outputJson) {
     console.log(JSON.stringify(data, undefined, 2))
-    return
+  } else {
+    const format = new ChalkOrMarkdown(!!outputMarkdown)
+    const url = `https://socket.dev/npm/reports/${encodeURIComponent(reportId)}`
+
+    console.log('\nDetailed info on socket.dev: ' + format.hyperlink(reportId, url, { fallbackToUrl: true }))
+    if (!outputMarkdown) {
+      console.log(chalk.dim('\nOr rerun', chalk.italic(name), 'using the', chalk.italic('--json'), 'flag to get full JSON output'))
+    }
   }
 
-  // ...else do the CLI / Markdown output dance
-
-  const format = new ChalkOrMarkdown(!!outputMarkdown)
-  const url = `https://socket.dev/npm/reports/${encodeURIComponent(reportId)}`
-
-  console.log('\nDetailed info on socket.dev: ' + format.hyperlink(reportId, url, { fallbackToUrl: true }))
-  if (!outputMarkdown) {
-    console.log(chalk.dim('\nOr rerun', chalk.italic(name), 'using the', chalk.italic('--json'), 'flag to get full JSON output'))
+  if (strict && objectSome(severityCount)) {
+    process.exit(1)
   }
 }

--- a/lib/utils/format-issues.js
+++ b/lib/utils/format-issues.js
@@ -1,15 +1,43 @@
 /** @typedef {import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>['data']} SocketIssueList */
 /** @typedef {SocketIssueList[number]['value'] extends infer U | undefined ? U : never} SocketIssue */
 
-import { stringJoinWithSeparateFinalSeparator } from './misc.js'
+import { pick, stringJoinWithSeparateFinalSeparator } from './misc.js'
+
+const SEVERITIES_BY_ORDER = /** @type {const} */ ([
+  'critical',
+  'high',
+  'middle',
+  'low',
+])
+
+/**
+ * @param {SocketIssue['severity']|undefined} lowestToInclude
+ * @returns {Array<SocketIssue['severity']>}
+ */
+ function getDesiredSeverities (lowestToInclude) {
+  /** @type {Array<SocketIssue['severity']>} */
+  const result = []
+
+  for (const severity of SEVERITIES_BY_ORDER) {
+    result.push(severity)
+    if (severity === lowestToInclude) {
+      break
+    }
+  }
+
+  return result
+}
 
 /**
  * @param {SocketIssueList} issues
+ * @param {SocketIssue['severity']} [lowestToInclude]
  * @returns {Record<SocketIssue['severity'], number>}
  */
-function getSeverityCount (issues) {
-  /** @type {Record<SocketIssue['severity'], number>} */
-  const severityCount = { low: 0, middle: 0, high: 0, critical: 0 }
+export function getSeverityCount (issues, lowestToInclude) {
+  const severityCount = pick(
+    { low: 0, middle: 0, high: 0, critical: 0 },
+    getDesiredSeverities(lowestToInclude)
+  )
 
   for (const issue of issues) {
     const value = issue.value
@@ -27,18 +55,18 @@ function getSeverityCount (issues) {
 }
 
 /**
- * @param {SocketIssueList} issues
+ * @param {Record<SocketIssue['severity'], number>} severityCount
  * @returns {string}
  */
-export function getSeveritySummary (issues) {
-  const severityCount = getSeverityCount(issues)
+export function formatSeverityCount (severityCount) {
+  /** @type {string[]} */
+  const summary = []
 
-  const issueSummary = stringJoinWithSeparateFinalSeparator([
-    severityCount.critical ? severityCount.critical + ' critical' : undefined,
-    severityCount.high ? severityCount.high + ' high' : undefined,
-    severityCount.middle ? severityCount.middle + ' middle' : undefined,
-    severityCount.low ? severityCount.low + ' low' : undefined,
-  ])
+  for (const severity of SEVERITIES_BY_ORDER) {
+    if (severityCount[severity]) {
+      summary.push(`${severityCount[severity]} ${severity}`)
+    }
+  }
 
-  return issueSummary
+  return stringJoinWithSeparateFinalSeparator(summary)
 }

--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -26,3 +26,36 @@ export function stringJoinWithSeparateFinalSeparator (list, separator = ' and ')
 
   return values.join(', ') + separator + finalValue
 }
+
+/**
+ * Returns a new object with only the specified keys from the input object
+ *
+ * @template {Record<string,any>} T
+ * @template {keyof T} K
+ * @param {T} input
+ * @param {K[]|ReadonlyArray<K>} keys
+ * @returns {Pick<T, K>}
+ */
+export function pick (input, keys) {
+  /** @type {Partial<Pick<T, K>>} */
+  const result = {}
+
+  for (const key of keys) {
+    result[key] = input[key]
+  }
+
+  return /** @type {Pick<T, K>} */ (result)
+}
+
+/**
+ * @param {Record<string,any>} obj
+ * @returns {boolean}
+ */
+export function objectSome (obj) {
+  for (const key in obj) {
+    if (obj[key]) {
+      return true
+    }
+  }
+  return false
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,18 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "module": "es2022",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+
+    /* New checks being tried out */
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+
+    /* Additional checks */
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   }
 }


### PR DESCRIPTION
To facilitate easy use in eg. CI environments a `--strict` flag has been added to fail with an exit code if any issues are found.

To ensure the usability of that command, plus to prepare for more comprehensive future outputs, all issues lower than `high` are now filtered out by default and a new flag `--all` is added to add these back in.