### PR TITLE
Add npm provenance GH action

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -1,0 +1,26 @@
+name: Publish Package to npmjs
+
+on:
+ release:
+   types: [created]
+
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   permissions:
+     contents: read
+     id-token: write
+
+   steps:
+     - uses: actions/checkout@v3
+     - uses: actions/setup-node@v3
+       with:
+         node-version: '18'
+         registry-url: 'https://registry.npmjs.org'
+         cache: npm
+     - run: npm install -g npm@latest
+     - run: npm ci
+     - run: npm publish --provenance --access public
+       env:
+         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will create an `npm publish` whenever a release is created on GH with proper npm provenance.