### PR TITLE
Add package scores to "socket info" command

### DIFF
--- a/lib/commands/info/index.js
+++ b/lib/commands/info/index.js
@@ -134,6 +134,10 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
     return handleUnsuccessfulApiResponse('getIssuesByNPMPackage', result, spinner)
   }
 
+  if (scoreResult.success === false) {
+    return handleUnsuccessfulApiResponse('getScoreByNPMPackage', scoreResult, spinner)
+  }
+
   // Conclude the status of the API call
 
   const severityCount = getSeverityCount(result.data, includeAllIssues ? undefined : 'high')
@@ -148,7 +152,6 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
   return {
     data: result.data,
     severityCount,
-    // @ts-ignore
     score: scoreResult.data
   }
 }

--- a/lib/commands/info/index.js
+++ b/lib/commands/info/index.js
@@ -115,6 +115,7 @@ function setupCommand (name, description, argv, importMeta) {
  * @typedef PackageData
  * @property {import('@socketsecurity/sdk').SocketSdkReturnType<'getIssuesByNPMPackage'>["data"]} data
  * @property {Record<import('../../utils/format-issues').SocketIssue['severity'], number>} severityCount
+ * @property {import('@socketsecurity/sdk').SocketSdkReturnType<'getScoreByNPMPackage'>["data"]} score
  */
 
 /**
@@ -127,6 +128,7 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
   const socketSdk = await setupSdk(getDefaultKey() || FREE_API_KEY)
   const spinner = ora(`Looking up data for version ${pkgVersion} of ${pkgName}`).start()
   const result = await handleApiCall(socketSdk.getIssuesByNPMPackage(pkgName, pkgVersion), 'looking up package')
+  const scoreResult = await handleApiCall(socketSdk.getScoreByNPMPackage(pkgName, pkgVersion), 'looking up package score')
 
   if (result.success === false) {
     return handleUnsuccessfulApiResponse('getIssuesByNPMPackage', result, spinner)
@@ -146,6 +148,7 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
   return {
     data: result.data,
     severityCount,
+    score: scoreResult.data
   }
 }
 
@@ -154,10 +157,21 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
  * @param {{ name: string } & CommandContext} context
  * @returns {void}
  */
- function formatPackageDataOutput ({ data, severityCount }, { name, outputJson, outputMarkdown, pkgName, pkgVersion, strict }) {
+ function formatPackageDataOutput ({ data, severityCount, score }, { name, outputJson, outputMarkdown, pkgName, pkgVersion, strict }) {
   if (outputJson) {
     console.log(JSON.stringify(data, undefined, 2))
   } else {
+    console.log('\nPackage report card:\n')
+
+    const scoreResult = {
+      'Supply Chain Risk': Math.floor(score.supplyChainRisk.score * 100),
+      'Maintenance': Math.floor(score.maintenance.score * 100),
+      'Quality': Math.floor(score.quality.score * 100),
+      'Vulnerabilities': Math.floor(score.vulnerability.score * 100),
+      'License': Math.floor(score.license.score * 100)
+    }
+    Object.entries(scoreResult).map(score => console.log(`- ${score[0]}: ${formatScore(score[1])}`))
+
     const format = new ChalkOrMarkdown(!!outputMarkdown)
     const url = `https://socket.dev/npm/package/${pkgName}/overview/${pkgVersion}`
 
@@ -169,5 +183,23 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
 
   if (strict && objectSome(severityCount)) {
     process.exit(1)
+  }
+}
+
+/**
+ * @param {number} score
+ * @returns {string}
+ */
+function formatScore (score) {
+  const error = chalk.hex('#de7c7b')
+  const warning = chalk.hex('#e59361')
+  const success = chalk.hex('#a4cb9d')
+
+  if (score > 80) {
+    return `${success(score)}`
+  } else if (score < 80 && score > 60) {
+    return `${warning(score)}`
+  } else {
+    return `${error(score)}`
   }
 }

--- a/lib/commands/info/index.js
+++ b/lib/commands/info/index.js
@@ -148,6 +148,7 @@ async function fetchPackageData (pkgName, pkgVersion, { includeAllIssues, strict
   return {
     data: result.data,
     severityCount,
+    // @ts-ignore
     score: scoreResult.data
   }
 }


### PR DESCRIPTION
## PR description:

This PR displays the package's scores when running the `socket info` command. To make it more visually appealing, I used a green color for scores over 80, an orange for scores between 60 and 80, and red for lower scores.

Example: Running `socket info info webtorrent@1.9.1` will display the following results.

<img width="393" alt="Screenshot 2023-11-08 at 5 08 29 PM" src="https://github.com/SocketDev/socket-cli-js/assets/5985247/c33e0f40-fb8c-4fdd-8912-c103a0b6cea5">

Running `socket info info iconfront@3.1.0`:

<img width="368" alt="Screenshot 2023-11-08 at 5 29 01 PM" src="https://github.com/SocketDev/socket-cli-js/assets/5985247/ed3cd475-09eb-4ff3-8031-dbbfef29a27a">