### PR TITLE
v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "CLI tool for Socket.dev",
   "homepage": "http://github.com/SocketDev/socket-cli-js",
   "repository": {


### PR DESCRIPTION
Various improvements to the `socket info` command:
- Displays the package's scores
- Displays the package's critical and high severity issues with a link to the Socket website for more information
- The command can now handle dist tags and no version. For example `socket info typescript@dev`, `socket info typescript@latest` or `socket info typescript`.