### PR TITLE
Fix logging module in newer versions of npm

### DIFF
--- a/lib/commands/npm/index.js
+++ b/lib/commands/npm/index.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, execSync } from 'child_process'
 import { fileURLToPath } from 'url'
 
 const description = 'npm wrapper functionality'
@@ -7,10 +7,15 @@ const description = 'npm wrapper functionality'
 export const npm = {
   description,
   run: async (argv, _importMeta, _ctx) => {
+    const npmVersion = execSync('npm -v').toString()
     const wrapperPath = fileURLToPath(new URL('../../shadow/npm-cli.cjs', import.meta.url))
     process.exitCode = 1
     spawn(process.execPath, [wrapperPath, ...argv], {
-      stdio: 'inherit'
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        NPM_VERSION: npmVersion
+      }
     }).on('exit', (code, signal) => {
       if (signal) {
         process.kill(process.pid, signal)

--- a/lib/shadow/npm-injection.cjs
+++ b/lib/shadow/npm-injection.cjs
@@ -268,7 +268,17 @@ function findRoot (filepath) {
 }
 const npmDir = findRoot(path.dirname(npmEntrypoint))
 const arboristLibClassPath = path.join(npmDir, 'node_modules', '@npmcli', 'arborist', 'lib', 'arborist', 'index.js')
-const npmlog = require(path.join(npmDir, 'node_modules', 'npmlog', 'lib', 'log.js'))
+
+const npmVersion = process.env.NPM_VERSION.split('.')
+let npmlog
+
+if(npmVersion[0] === '10' && npmVersion[1] >= '7'){
+  const { log } = require(path.join(npmDir, 'node_modules', 'proc-log', 'lib', 'index.js'))
+  npmlog = log
+} else {
+  npmlog = require(path.join(npmDir, 'node_modules', 'npmlog', 'lib', 'log.js'))
+}
+
 /**
  * @type {import('pacote')}
  */

--- a/lib/shadow/npm-injection.cjs
+++ b/lib/shadow/npm-injection.cjs
@@ -272,7 +272,7 @@ const arboristLibClassPath = path.join(npmDir, 'node_modules', '@npmcli', 'arbor
 const npmVersion = process.env.NPM_VERSION.split('.')
 let npmlog
 
-if(npmVersion[0] === '10' && npmVersion[1] >= '7'){
+if(npmVersion[0] === '10' && npmVersion[1] >= '6'){
   const { log } = require(path.join(npmDir, 'node_modules', 'proc-log', 'lib', 'index.js'))
   npmlog = log
 } else {


### PR DESCRIPTION
npm v10.6.0 + doesn't have the module `npmlog` as dependency anymore. Instead, it uses `proc-log` so I updated our wrapper to import the correct module based on the npm version used. Feels like a bit of a hack so let me know if you think of a better way.