### PR TITLE
[fix] Refactor to add auth error handling

### DIFF
--- a/src/commands/organization.ts
+++ b/src/commands/organization.ts
@@ -9,6 +9,7 @@ import {
 import { getDefaultKey, setupSdk } from '../utils/sdk'
 
 import type { CliSubcommand } from '../utils/meow-with-subcommands'
+import { AuthError } from '../utils/errors'
 
 export const organizations: CliSubcommand = {
   description: 'List organizations associated with the API key used',
@@ -42,6 +43,9 @@ function setupCommand(
 
 async function fetchOrganizations(): Promise<void> {
   const apiKey = getDefaultKey()
+  if(!apiKey){
+    throw new AuthError("User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.")
+  }
   const socketSdk = await setupSdk(apiKey)
   const spinner = ora('Fetching organizations...').start()
 
@@ -57,13 +61,10 @@ async function fetchOrganizations(): Promise<void> {
   spinner.stop()
 
   const organizations = Object.values(result.data.organizations)
-  if (apiKey) {
-    console.log(
-      `List of organizations associated with your API key: ${chalk.italic(apiKey)}`
-    )
-  } else {
-    console.log('List of organizations associated with your API key.')
-  }
+  
+  console.log(
+    `List of organizations associated with your API key: ${chalk.italic(apiKey)}`
+  )
 
   for (const o of organizations) {
     console.log(`

--- a/src/commands/report/index.ts
+++ b/src/commands/report/index.ts
@@ -4,7 +4,7 @@ import { meowWithSubcommands } from '../../utils/meow-with-subcommands'
 
 import type { CliSubcommand } from '../../utils/meow-with-subcommands'
 
-const description = 'Project report related commands'
+const description = '[Deprecated] Project report related commands'
 
 export const report: CliSubcommand = {
   description,

--- a/src/commands/repos/list.ts
+++ b/src/commands/repos/list.ts
@@ -14,6 +14,7 @@ import { getDefaultKey, setupSdk } from '../../utils/sdk'
 
 import type { CliSubcommand } from '../../utils/meow-with-subcommands'
 import type { Ora } from 'ora'
+import { AuthError } from '../../utils/errors'
 
 export const list: CliSubcommand = {
   description: 'List repositories in an organization',
@@ -21,9 +22,13 @@ export const list: CliSubcommand = {
     const name = `${parentName} list`
     const input = setupCommand(name, list.description, argv, importMeta)
     if (input) {
+      const apiKey = getDefaultKey()
+      if(!apiKey){
+        throw new AuthError("User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.")
+      }
       const spinnerText = 'Listing repositories... \n'
       const spinner = ora(spinnerText).start()
-      await listOrgRepos(input.orgSlug, input, spinner)
+      await listOrgRepos(input.orgSlug, input, spinner, apiKey)
     }
   }
 }
@@ -129,9 +134,10 @@ function setupCommand(
 async function listOrgRepos(
   orgSlug: string,
   input: CommandContext,
-  spinner: Ora
+  spinner: Ora,
+  apiKey: string
 ): Promise<void> {
-  const socketSdk = await setupSdk(getDefaultKey())
+  const socketSdk = await setupSdk(apiKey)
   const result = await handleApiCall(
     socketSdk.getOrgRepoList(orgSlug, input),
     'listing repositories'

--- a/src/commands/repos/update.ts
+++ b/src/commands/repos/update.ts
@@ -12,6 +12,7 @@ import { getDefaultKey, setupSdk } from '../../utils/sdk'
 
 import type { CliSubcommand } from '../../utils/meow-with-subcommands'
 import type { Ora } from 'ora'
+import { AuthError } from '../../utils/errors'
 
 export const update: CliSubcommand = {
   description: 'Update a repository in an organization',
@@ -19,9 +20,13 @@ export const update: CliSubcommand = {
     const name = `${parentName} update`
     const input = setupCommand(name, update.description, argv, importMeta)
     if (input) {
+      const apiKey = getDefaultKey()
+      if(!apiKey){
+        throw new AuthError("User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.")
+      }
       const spinnerText = 'Updating repository... \n'
       const spinner = ora(spinnerText).start()
-      await updateRepository(input.orgSlug, input, spinner)
+      await updateRepository(input.orgSlug, input, spinner, apiKey)
     }
   }
 }
@@ -145,9 +150,10 @@ function setupCommand(
 async function updateRepository(
   orgSlug: string,
   input: CommandContext,
-  spinner: Ora
+  spinner: Ora,
+  apiKey: string
 ): Promise<void> {
-  const socketSdk = await setupSdk(getDefaultKey())
+  const socketSdk = await setupSdk(apiKey)
   const result = await handleApiCall(
     socketSdk.updateOrgRepo(orgSlug, input.name, input),
     'updating repository'

--- a/src/commands/scan/create.ts
+++ b/src/commands/scan/create.ts
@@ -18,6 +18,7 @@ import { getDefaultKey, setupSdk } from '../../utils/sdk'
 
 import type { CliSubcommand } from '../../utils/meow-with-subcommands'
 import type { Ora } from 'ora'
+import { AuthError } from '../../utils/errors'
 
 export const create: CliSubcommand = {
   description: 'Create a scan',
@@ -25,9 +26,13 @@ export const create: CliSubcommand = {
     const name = `${parentName} create`
     const input = await setupCommand(name, create.description, argv, importMeta)
     if (input) {
+      const apiKey = getDefaultKey()
+      if(!apiKey){
+        throw new AuthError("User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.")
+      }
       const spinnerText = 'Creating a scan... \n'
       const spinner = ora(spinnerText).start()
-      await createFullScan(input, spinner)
+      await createFullScan(input, spinner, apiKey)
     }
   }
 }
@@ -203,9 +208,10 @@ async function setupCommand(
 
 async function createFullScan(
   input: CommandContext,
-  spinner: Ora
+  spinner: Ora,
+  apiKey: string
 ): Promise<void> {
-  const socketSdk = await setupSdk(getDefaultKey())
+  const socketSdk = await setupSdk(apiKey)
   const {
     orgSlug,
     repoName,


### PR DESCRIPTION
This PR implements error handling on commands that require the user to be authenticated.
For example, if a user is not logged into the CLI and tries to run the command `socket dependencies` or `socket organizations`, the following error message will be displayed:

```
✖ Authentication error: User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.
```