### PR TITLE
[fix] safe-npm spinner issue

### DIFF
--- a/src/shadow/npm-cli.ts
+++ b/src/shadow/npm-cli.ts
@@ -5,6 +5,7 @@ import { realpathSync } from 'node:fs'
 import path from 'node:path'
 
 import { installLinks } from './link'
+import { findRoot } from '../utils/path-resolve'
 
 const realFilename = realpathSync(__filename)
 const realDirname = path.dirname(realFilename)
@@ -14,9 +15,32 @@ const injectionPath = path.join(realDirname, 'npm-injection.js')
 
 process.exitCode = 1
 
+/* 
+  Adding the `--quiet` and `--no-progress` flags when the `proc-log` module 
+  is found to fix a UX issue when running the command with recent versions of npm
+  (input swallowed by the standard npm spinner) 
+*/ 
+let npmArgs: string[] = []
+if(process.argv.slice(2).includes('install')){
+  const npmEntrypoint = realpathSync(npmPath)
+  const npmRootPath = findRoot(path.dirname(npmEntrypoint))
+  if (npmRootPath === undefined) {
+    process.exit(127)
+  }
+  const npmDepPath = path.join(npmRootPath, 'node_modules')
+
+  let npmlog
+  try {
+    npmlog = require(path.join(npmDepPath, 'proc-log/lib/index.js')).log
+  } catch {}
+  if (npmlog) {
+    npmArgs = ['--quiet', '--no-progress']
+  } 
+} 
+
 spawn(
   process.execPath,
-  ['--require', injectionPath, npmPath, ...process.argv.slice(2)],
+  ['--require', injectionPath, npmPath, ...process.argv.slice(2), ...npmArgs],
   {
     stdio: 'inherit'
   }

--- a/src/shadow/npm-injection.ts
+++ b/src/shadow/npm-injection.ts
@@ -27,6 +27,7 @@ import type {
 } from '@npmcli/arborist'
 import type { Writable } from 'node:stream'
 import type { Options as OraOptions } from 'ora'
+import { findRoot } from '../utils/path-resolve'
 
 type ArboristClass = typeof BaseArborist & {
   new (...args: any): any
@@ -172,20 +173,6 @@ async function* batchScan(
   const rli = rl.createInterface(res)
   for await (const line of rli) {
     yield JSON.parse(line)
-  }
-}
-
-function findRoot(filepath: string): string | undefined {
-  let curPath = filepath
-  while (true) {
-    if (path.basename(curPath) === 'npm') {
-      return curPath
-    }
-    const parent = path.dirname(curPath)
-    if (parent === curPath) {
-      return undefined
-    }
-    curPath = parent
   }
 }
 

--- a/src/utils/path-resolve.ts
+++ b/src/utils/path-resolve.ts
@@ -134,3 +134,17 @@ export async function mapGlobEntryToFiles(
 
   return files
 }
+
+export function findRoot(filepath: string): string | undefined {
+  let curPath = filepath
+  while (true) {
+    if (path.basename(curPath) === 'npm') {
+      return curPath
+    }
+    const parent = path.dirname(curPath)
+    if (parent === curPath) {
+      return undefined
+    }
+    curPath = parent
+  }
+}


### PR DESCRIPTION
When using recent versions of node & npm, the `npmlog` module is replaced with `proc-log`. This introduced a UX bug where the `safe npm` command output was getting swallowed by the default `npm install` spinner, so when the user is prompted to accept or reject potentially malicious packages, the input disappears.

This PR implements a fix. [Demo](https://www.loom.com/share/7a59fa54237c47598625abd5446dc31b?sid=4f7d506f-4e30-44b7-9df2-8194c37b8c89)